### PR TITLE
add "conn" and "err" states to display

### DIFF
--- a/ArduinoAQI.ino
+++ b/ArduinoAQI.ino
@@ -5,6 +5,8 @@
 #include "ArduinoAQIData.h"
 #include "CalculateAQI.h"
 
+static const uint16_t PMS_TIMEOUT_MS = 2000;
+
 Button resetButton(PIN_RESET);
 SevenSegmentSnake display(PIN_LED_CLK, PIN_LED_DIO);
 
@@ -107,9 +109,14 @@ void clearDisplay() {
   display.print("----");
 }
 
+void setDisplay(const char *text) {
+  display.clear();
+  display.print(text);
+}
+
 void onAPMode(WiFiManager *myWiFiManager) {
   Serial.println("Creating access point: " + myWiFiManager->getConfigPortalSSID());
-  clearDisplay();
+  setDisplay("conn");
 }
 
 void connectWifi() {
@@ -156,7 +163,7 @@ unsigned long getRateLimitSeconds() {
 }
 
 void processSensorData(bool trace) {
-  if (pms.read(pmsData)) {
+  if (pms.readUntil(pmsData, PMS_TIMEOUT_MS)) {
     if (trace) {
       Serial.print("PM 1.0 (ug/m3): ");
       Serial.println(pmsData.PM_AE_UG_1_0);
@@ -174,8 +181,7 @@ void processSensorData(bool trace) {
     float aqi = CalculateAQI::getPM25AQI(pmsData.PM_AE_UG_2_5);
     
     // display realtime unaveraged AQI
-    display.clear();
-    display.print(getNumberWithLeadingZeros(round(aqi), DISPLAY_LENGTH));
+    setDisplay(getNumberWithLeadingZeros(round(aqi), DISPLAY_LENGTH));
     
     if (!isWifiMode) return;
 
@@ -198,6 +204,8 @@ void processSensorData(bool trace) {
     resetSensorAverages();
   
     lastDataSend = millis();
+  } else {
+    setDisplay("err");
   }
 }
 

--- a/ArduinoAQI.ino
+++ b/ArduinoAQI.ino
@@ -78,11 +78,8 @@ bool wasWifiModeDisabled() {
   return disableWifi == 1;
 }
 
-char* getNumberWithLeadingZeros(long num, int displayLength) {
-  char buffer[displayLength];
-  String pattern = "%0" + String(displayLength) + "d";
-  sprintf(buffer, pattern.c_str(), num);
-  
+char *getNumberWithLeadingZeros(long num, char *buffer, int displayLength) {
+  snprintf(buffer, ((size_t) displayLength) + 1, "%0*ld", displayLength, num);
   return buffer;
 }
 
@@ -181,7 +178,8 @@ void processSensorData(bool trace) {
     float aqi = CalculateAQI::getPM25AQI(pmsData.PM_AE_UG_2_5);
     
     // display realtime unaveraged AQI
-    setDisplay(getNumberWithLeadingZeros(round(aqi), DISPLAY_LENGTH));
+    char displayBuffer[DISPLAY_LENGTH + 1];
+    setDisplay(getNumberWithLeadingZeros(round(aqi), displayBuffer, DISPLAY_LENGTH));
     
     if (!isWifiMode) return;
 


### PR DESCRIPTION
currently it's easy to get confused between the various states the device can be in wrt wifi disabled/connecting/AP-setup,
which all display "----", so this adds "conn" to the display instead during the AP-setup mode. in addition, it's useful
to be able to tell when the device can't read from the sensor, so a 2s timeout is added along with "err" on the display
in case no valid data was read.

also fixes a couple memory safety issues i happened to find with getNumberWithLeadingZeroes

tested on my device