### PR TITLE
add optional setup AP password

### DIFF
--- a/ArduinoAQIData.cpp
+++ b/ArduinoAQIData.cpp
@@ -17,7 +17,7 @@ void ArduinoAQIData::begin() {
     Serial.println("WiFi config saved");
   });
   
-  _wifiManager.autoConnect(ACCESS_POINT);
+  _wifiManager.autoConnect(ACCESS_POINT, ACCESS_POINT_PASSWORD);
   
   _onWifiConnect();
 }

--- a/ArduinoAQIData.h
+++ b/ArduinoAQIData.h
@@ -11,6 +11,10 @@
 #include "src/WiFiManager/WiFiManager.h"
 #include "private/config.h"
 
+#ifndef ACCESS_POINT_PASSWORD
+# define ACCESS_POINT_PASSWORD NULL
+#endif
+
 struct Credentials {
   String ssid;
   String password;

--- a/config.h
+++ b/config.h
@@ -1,4 +1,5 @@
 #define ACCESS_POINT "ArduinoAQI Setup"
+#define ACCESS_POINT_PASSWORD NULL // non-NULL string of length 8-63 bytes sets a password to enable WPA2 encryption
 #define THINGSPEAK_REGISTRY_CHANNEL_NUMBER 0
 #define THINGSPEAK_REGISTRY_API_KEY ""
 #define THINGSPEAK_DEFAULT_DATA_CHANNEL_NUMBER 0


### PR DESCRIPTION
motivation: typing a wifi password into the unencrypted setup landing page on the unencrypted setup-mode AP leaves the
password in plaintext vulnerable to passive wifi monitoring. this commit allows setting a password enabling WPA2 for the
setup-mode AP

tested with/without password on my wemos d1 r2 device